### PR TITLE
Trie.java had Sun's Tree, but wasn't used, this unblocks OpenJDK

### DIFF
--- a/src/trie/Trie.java
+++ b/src/trie/Trie.java
@@ -1,7 +1,5 @@
 package trie;
 
-import com.sun.source.tree.Tree;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.lang.invoke.WrongMethodTypeException;


### PR DESCRIPTION
Looks like there was a reference to a Sun 'Tree' pakcage, but unused.  The below worked after I removed

```
[ec2-user@ip-10-82-208-122 wordle]$ ./gradlew --stacktrace clean build run

> Task :run
[kinda, panic, ninja, mania, manic, vinca, ixnay]

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.3.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 6s
7 actionable tasks: 7 executed
[ec2-user@ip-10-82-208-122 wordle]$
```