### PR TITLE
Feature/web service url params

### DIFF
--- a/web_service/README.md
+++ b/web_service/README.md
@@ -19,11 +19,14 @@ This is a wrapping class to prevent multiple instances of Wordle functional clas
 `../gradlew bootRun`
 
 ```
+# index
 curl localhost:8080
-curl localhost:8080/demoTrie
-# the latter to be replaced by better parameterized endpoints
-# also will render JSON in the future
-curl localhost:8080/demoTrie?missingCharsCSV=a,r,s,m,o,v,t,l,h&charGuessesMap=0n,2c&currentGuess=-i--e
+
+# renders JSON response
+curl "localhost:8080/demoTrie?missingCharsCSV=a,r,s,m,o,v,t,l,h&charGuessesMapCSV=0n,2c&currentGuess=-i--e"
+
+# invalid request, curl printing Header+httpCode
+curl -i "localhost:8080/demoTrie?missingCharsCSV=a,rt,s,m,o,v,t,l,h&charGuessesMapCSV=0n,2c&currentGuess=-i--e"
 ```
 
 ## Unit Tests

--- a/web_service/README.md
+++ b/web_service/README.md
@@ -23,6 +23,7 @@ curl localhost:8080
 curl localhost:8080/demoTrie
 # the latter to be replaced by better parameterized endpoints
 # also will render JSON in the future
+curl localhost:8080/demoTrie?missingCharsCSV=a,r,s,m,o,v,t,l,h&charGuessesMap=0n,2c&currentGuess=-i--e
 ```
 
 ## Unit Tests
@@ -31,5 +32,5 @@ curl localhost:8080/demoTrie
 ../gradlew clean test (-i)
 
 # ...or speicific Class
-./gradlew clean test --tests SerializerTests -i
+../gradlew clean test --tests WordleSolverApplicationTests -i
 ```

--- a/web_service/src/main/java/web/wordle_solver/Controller.java
+++ b/web_service/src/main/java/web/wordle_solver/Controller.java
@@ -1,9 +1,12 @@
 package web.wordle_solver;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import web.utils.Serializer;
+
+import java.util.StringTokenizer;
 
 // for demonstration purposes only
 import trie.WordWrapper;
@@ -25,11 +28,18 @@ public class Controller {
 
 	// for demonstration purposes only
 	@GetMapping("/demoTrie")
-	public String demoTrie() {
+	public String demoTrie(@RequestParam String missingCharsCSV) {
+
+		System.out.println(missingCharsCSV);
+		HashSet<Character> missingChars = new HashSet(26);
+		StringTokenizer st = new StringTokenizer(missingCharsCSV, ",");
+		while (st.hasMoreTokens()) {
+			//TODO, check if length too long....., raise exception
+			missingChars.add(st.nextToken().charAt(0));
+		}
+
 		SingletonSteward singletonSteward = SingletonSteward.getInstance();
 
-		final HashSet<Character> missingChars = Stream.of('a', 'r', 's', 'm', 'o', 'v', 't', 'l', 'h')
-                .collect(Collectors.toCollection(HashSet::new));
         final HashSet<Character> wrongSlotChars = Stream.of('o')
                 .collect(Collectors.toCollection(HashSet::new));
         Map<Character, Set<Integer>> charGuessesMap = new HashMap<>();
@@ -40,7 +50,6 @@ public class Controller {
         final SortedSet<WordWrapper> potentialWords = singletonSteward.trie.generatePotentialWords("-i--e", charGuessesMap,
                 missingChars);
 
-		// to be replaced
 		String potentialWordsJSON = Serializer.createJSONString(potentialWords);
 
 		return potentialWordsJSON;

--- a/web_service/src/test/java/web/wordle_solver/WordleSolverApplicationTests.java
+++ b/web_service/src/test/java/web/wordle_solver/WordleSolverApplicationTests.java
@@ -29,10 +29,37 @@ public class WordleSolverApplicationTests {
 
 	@Test
 	public void demoTrieEndpoint() throws Exception {
-		mvc.perform(MockMvcRequestBuilders.get("/demoTrie?missingCharsCSV=a,r,s,m,o,v,t,l,h&charGuessesMap=0n,2c&currentGuess=-i--e")
+		mvc.perform(MockMvcRequestBuilders.get("/demoTrie?missingCharsCSV=a,r,s,m,o,v,t,l,h&charGuessesMapCSV=0n,2c&currentGuess=-i--e")
 			.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(content().string(equalTo("{\"potentialWords\":[\"wince\"]}")));
+	}
+
+	@Test
+	public void requesetWithBadMissingCharsCSV() throws Exception {
+		String notChar = "br";
+		mvc.perform(MockMvcRequestBuilders.get("/demoTrie?missingCharsCSV=a,"+notChar+",s,m,o,v,t,l,h&charGuessesMapCSV=0n,2c&currentGuess=-i--e")
+			.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().is4xxClientError())
+			.andExpect(content().string(equalTo("missingCharsCSV contains non-char: " + notChar)));
+	}
+
+	@Test
+	public void requesetWithBadCharGuessMap() throws Exception {
+		String badMapPair = "02b";
+		mvc.perform(MockMvcRequestBuilders.get("/demoTrie?missingCharsCSV=a,s,m,o,v,t,l,h&charGuessesMapCSV=0n,"+badMapPair+"&currentGuess=-i--e")
+			.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().is4xxClientError())
+			.andExpect(content().string(equalTo("charGuessesMapCSV contains bad map pair: " + badMapPair)));
+	}
+
+	@Test
+	public void requesetWithBadCurrentGuess() throws Exception {
+		String badCurrentGuess = "-i--e---";
+		mvc.perform(MockMvcRequestBuilders.get("/demoTrie?missingCharsCSV=a,s,m,o,v,t,l,h&charGuessesMapCSV=0n&currentGuess="+badCurrentGuess)
+			.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().is4xxClientError())
+			.andExpect(content().string(equalTo("currentGuess is invalid: " + badCurrentGuess)));
 	}
 
 }

--- a/web_service/src/test/java/web/wordle_solver/WordleSolverApplicationTests.java
+++ b/web_service/src/test/java/web/wordle_solver/WordleSolverApplicationTests.java
@@ -29,9 +29,10 @@ public class WordleSolverApplicationTests {
 
 	@Test
 	public void demoTrieEndpoint() throws Exception {
-		mvc.perform(MockMvcRequestBuilders.get("/demoTrie").accept(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk())
-				.andExpect(content().string(equalTo("{\"potentialWords\":[\"wince\"]}")));
+		mvc.perform(MockMvcRequestBuilders.get("/demoTrie?missingCharsCSV=a,r,s,m,o,v,t,l,h&charGuessesMap=0n,2c&currentGuess=-i--e")
+			.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string(equalTo("{\"potentialWords\":[\"wince\"]}")));
 	}
 
 }


### PR DESCRIPTION
The endpoint now accepts three request params, which are correctly parsed and fed to `Trie.generatePotentialWords()`

`curl "localhost:8080/demoTrie?missingCharsCSV=a,r,s,m,o,v,t,l,h&charGuessesMapCSV=0n,2c&currentGuess=-i--e"`

Still a 'demo' endpoint, until the final UX angle is clear, but the plumbing coded here will make changes very easy to do with code re-use
