### PR TITLE
Deployment fixes deprecated lamdba

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,48 +4,48 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Build with Gradle
         run: ./gradlew build
   unittest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Run unit tests
         run: ./gradlew clean test
   unittest-web-service:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Run unit tests
         run: cd web_service && ../gradlew clean test
   unittest-lambda-function:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Run unit tests
         run: cd lambda_function && ../gradlew clean test

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ This command is not useful, but syntax handy for future gradle work:
 
 # Sub Projects
 
+## Deployment hints
+
+(for debugging hints)
+
+Lambda: `lambda_function/` contains scripts for the mvn/gradle build, package, and cloudformation deployment.  The java code contains Header additions for `Access-Control-Allow-Origin` to match the ultimate deployed domain.
+
+API GW: manually created, pointing to the Lambda.
+
+S3: manually created, contains the file `lambda_function/static_html/index.html` (but with `apiURL_base`) pointed to the API GW.
+
 ## Lambda_Function
 
 The directory `lambda_function` contains an AWS `RequestStreamHandler` which will expose functionality from the overall `wordle` repo.  There are also supporting bash scripts for deployment via AWS CLI.  See [lambda_function/README.md](web_service/README.md) for more detail.

--- a/lambda_function/static_html/index.html
+++ b/lambda_function/static_html/index.html
@@ -294,7 +294,8 @@ input[id='missingChars'], textarea {
             }
           },
           error: function(error) {
-            console.log(`Error: ${error}`)
+            console.log(`Error: ${error.status}`)
+            console.log(`Error: ${error.responseText}`)
           },
           complete: function(data) {
             setTimeout(function() {

--- a/lambda_function/static_html/index.html
+++ b/lambda_function/static_html/index.html
@@ -275,7 +275,7 @@ input[id='missingChars'], textarea {
         var missingCharsCSV = collectMissingCharsCSV();
 
          // Make the call
-         var apiURL_base = ""
+         var apiURL_base = "https://5nis79o3ld.execute-api.us-east-1.amazonaws.com/prod/crunch"
         $.ajax({
           url: `${apiURL_base}?missingCharsCSV=${missingCharsCSV}&charGuessesMapCSV=${charGuessesMapCSV}&currentGuess=${currentGuess}`,
           type: "GET",


### PR DESCRIPTION
ugh this was down for months, that lambda runtime java8 was deprecated, I manually moved to java11, and in the process had to relearn the deployment path.  I didn't end up re-deploying, but leaving these hints here for next CI refactor/cleanup, or next necessary deployment